### PR TITLE
PHC-5429 - Bump react-native-sdk to 1.7.0 with TrackTiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format:write": "yarn format --write"
   },
   "dependencies": {
-    "@lifeomic/react-native-sdk": "^1.5.6",
+    "@lifeomic/react-native-sdk": "1.7.0",
     "@react-native-async-storage/async-storage": "^1.18.1",
     "@react-native-community/netinfo": "^9.3.8",
     "@react-native-picker/picker": "^2.4.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,10 +1614,10 @@
   resolved "https://registry.yarnpkg.com/@lifeomic/chromicons-native/-/chromicons-native-2.16.0.tgz#fe1a6c4b57bca21e2ce1f2d8d575a1b014c983b1"
   integrity sha512-foPeepmhnW3qTLYVvjV1vozxi9FjdQCDjhJ1tv8PJMleRCw5jdzaJZV1/QLWC5/ZrQrK68xtD7Ei1qb6HZbpQA==
 
-"@lifeomic/react-native-sdk@^1.5.6":
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/@lifeomic/react-native-sdk/-/react-native-sdk-1.5.6.tgz#1feca2cb6e1ed8e0fbf1900448b1f952f2dc81eb"
-  integrity sha512-TmFjjqQvOHT/cZoo6qzNMNAmSpjYY5ldXE+5Ta2aqzpEuaMr6fRxcpjC4tRGzxUkNKCKHLms/fIUy1LBoCo/2g==
+"@lifeomic/react-native-sdk@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@lifeomic/react-native-sdk/-/react-native-sdk-1.7.0.tgz#a09ceefd5b328f6fcec01d596262ee4913cf4581"
+  integrity sha512-x1gAlLSxVxH/fE8hRDY6PZoa4zQB3aRAgDs8YMLu0vZ3Gy+V/DIAa4xy8XVJta+hhvzlwDD7+OkoKWXy0z0xHg==
   dependencies:
     "@lifeomic/chromicons-native" "^2.14.0"
     "@types/fhir" "^0.0.36"


### PR DESCRIPTION
![Screenshot 2023-04-21 at 1 08 25 PM](https://user-images.githubusercontent.com/220893/233694950-2f8121b5-83b7-43d7-8903-c020b7ddd087.png)
