### PR TITLE
Add offline_access scope to support refresh tokens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,18 @@ const authConfig: AuthConfiguration = {
     tokenEndpoint: OAuth.tokenEndpoint,
     revocationEndpoint: OAuth.revokeEndpoint,
   },
-  scopes: ['openid', 'profile', 'offline_access'],
+  scopes: [
+    'openid',
+    'profile',
+    // We must request this scope in order to get a refresh token,
+    // and a refresh token is required for this app to function
+    // as expected. So, provide it.
+    'offline_access',
+  ],
   usePKCE: true,
   additionalParameters: {
+    // This value must be specified when we are requesting `offline_access`.
+    // See for context: https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
     prompt: 'consent',
   },
   iosPrefersEphemeralSession: true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const authConfig: AuthConfiguration = {
     tokenEndpoint: OAuth.tokenEndpoint,
     revocationEndpoint: OAuth.revokeEndpoint,
   },
-  scopes: ['openid', 'profile'],
+  scopes: ['openid', 'profile', 'offline_access'],
   usePKCE: true,
   additionalParameters: {
     prompt: 'consent',


### PR DESCRIPTION
## Motivation
This scope is required if we want to get a refresh token, which we _must_ get for the app to function as expected.

Context: https://lifeomic.slack.com/archives/C05KMKQNTAR/p1691154920362339