### PR TITLE
fix: remove deprecated accentColor

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,5 +8,4 @@ export const oauthConfig = {
 
 export const simpleTheme = {
   primaryColor: '#67595E',
-  accentColor: '#A49393',
 };


### PR DESCRIPTION
# Motivations

I noticed that `accentColor` is no longer used by the SDK. 